### PR TITLE
Refactor: introduce DocumentService and versioning

### DIFF
--- a/PaperlessREST.Tests/Database.Tests/DocumentTests.cs
+++ b/PaperlessREST.Tests/Database.Tests/DocumentTests.cs
@@ -1,88 +1,39 @@
-﻿using System.Text.Json;
-using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using PaperlessREST.Controllers;
-using PaperlessREST.Data;
-using PaperlessREST.Models;
-using Xunit;
-using Microsoft.Extensions.Logging;
-using PaperlessREST.Services;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Paperless.Contracts.SharedServices;
 using Paperless.REST.Models;
+using PaperlessREST.Data;
+using PaperlessREST.Models;
+using PaperlessREST.Services;
+using PaperlessREST.Services.Documents; // <- wherever you placed DocumentService/IDocumentService
+using System.Text.Json;
+using Xunit;
 
-public class DocumentRepositoryTests : IClassFixture<PostgresFixture>
-{
-    private readonly PostgresFixture _fixture;
-
-    public DocumentRepositoryTests(PostgresFixture fixture)
-    {
-        _fixture = fixture;
-    }
-
-    [Fact]
-    public async Task AddDocument_ShouldPersistAndRetrieve()
-    {
-        // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseNpgsql(_fixture.ConnectionString)
-            .Options;
-
-        using (var db = new AppDbContext(options))
-        {
-            var doc = new Document
-            {
-                FileName = "test.pdf",
-                CreatedAt = DateTime.UtcNow
-            };
-
-            // add a version (the Document no longer has Content directly)
-            doc.Versions = new List<DocumentVersion>
-            {
-                new DocumentVersion
-                {
-                    VersionNumber = 1,
-                    ContentType = "application/pdf",
-                    SizeBytes = 0,
-                    SummarizedContent = "Hello World"
-                }
-            };
-
-            db.Documents.Add(doc);
-            await db.SaveChangesAsync();
-
-            // set current version to the newly created version
-            doc.CurrentVersionId = doc.Versions.First().Id;
-            await db.SaveChangesAsync();
-        }
-
-        // Assert
-        using (var db = new AppDbContext(options))
-        {
-            var docs = await db.Documents.Include(d => d.Versions).ToListAsync();
-            Assert.Single(docs);
-            Assert.Equal("test.pdf", docs[0].FileName);
-            Assert.NotEmpty(docs[0].Versions);
-            Assert.Equal("Hello World", docs[0].Versions.First().SummarizedContent);
-        }
-    }
-}
-
-public class DocumentsController_Update_Tests : IClassFixture<PostgresFixture>
+public class DocumentServiceTests : IClassFixture<PostgresFixture>
 {
     private readonly string _cs;
-    public DocumentsController_Update_Tests(PostgresFixture fx) => _cs = fx.ConnectionString;
+
+    public DocumentServiceTests(PostgresFixture fx) => _cs = fx.ConnectionString;
 
     private AppDbContext NewDb()
-        => new(new DbContextOptionsBuilder<AppDbContext>()
-               .UseNpgsql(_cs).Options);
+        => new(new DbContextOptionsBuilder<AppDbContext>().UseNpgsql(_cs).Options);
+
+    private static void CleanDocuments(AppDbContext db)
+    {
+        db.Database.Migrate();
+        var et = db.Model.FindEntityType(typeof(Document))!;
+        var schema = et.GetSchema() ?? "public";
+        var table = et.GetTableName()!;
+        db.Database.ExecuteSqlRaw($@"TRUNCATE TABLE ""{schema}"".""{table}"" RESTART IDENTITY CASCADE");
+    }
 
     [Fact]
-    public async Task GetExistingDocumentById()
+    public async Task GetByIdAsync_ReturnsExpectedDocumentShape()
     {
-        // Arrange
         int id;
+
+        // Arrange DB
         using (var db = NewDb())
         {
             CleanDocuments(db);
@@ -91,23 +42,12 @@ public class DocumentsController_Update_Tests : IClassFixture<PostgresFixture>
             {
                 new Document {
                     FileName = "test1",
-                    Versions = new List<DocumentVersion> {
-                        new DocumentVersion { VersionNumber = 1, SummarizedContent = "dummyContent", ContentType = "application/pdf", SizeBytes = 0 }
-                    },
+                    Versions = new() { new DocumentVersion { VersionNumber = 1, SummarizedContent="dummy", ContentType="application/pdf", SizeBytes=0 } },
                     CreatedAt = DateTime.UtcNow
                 },
                 new Document {
                     FileName = "this should be returned",
-                    Versions = new List<DocumentVersion> {
-                        new DocumentVersion { VersionNumber = 1, SummarizedContent = "this is the content", ContentType = "application/pdf", SizeBytes = 0 }
-                    },
-                    CreatedAt = DateTime.UtcNow
-                },
-                new Document {
-                    FileName = "blah",
-                    Versions = new List<DocumentVersion> {
-                        new DocumentVersion { VersionNumber = 1, SummarizedContent = "blah", ContentType = "application/pdf", SizeBytes = 0 }
-                    },
+                    Versions = new() { new DocumentVersion { VersionNumber = 1, SummarizedContent="this is the content", ContentType="application/pdf", SizeBytes=0 } },
                     CreatedAt = DateTime.UtcNow
                 }
             };
@@ -115,118 +55,101 @@ public class DocumentsController_Update_Tests : IClassFixture<PostgresFixture>
             db.Documents.AddRange(docs);
             await db.SaveChangesAsync();
 
-            // set current version ids now that versions have ids
             foreach (var d in docs)
-            {
                 d.CurrentVersionId = d.Versions.First().Id;
-            }
+
             await db.SaveChangesAsync();
 
             id = docs[1].Id;
         }
 
-        // Act
-        IActionResult result;
-        var elasticMock = new Mock<IElasticService>();
+        // Arrange service with mocks
+        using (var db = NewDb())
+        {
+            var storageMock = new Mock<IObjectStorage>(MockBehavior.Strict);
+            var mqMock = new Mock<IMessageQueueService>(MockBehavior.Strict);
+            var elasticMock = new Mock<IElasticService>(MockBehavior.Strict);
+
+            var svc = new DocumentService(
+                db,
+                NullLogger<DocumentService>.Instance,
+                storageMock.Object,
+                mqMock.Object,
+                elasticMock.Object);
+
+            // Act
+            var result = await svc.GetByIdAsync(id, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+
+            var json = JsonSerializer.Serialize(result);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            Assert.Equal("this should be returned", root.GetProperty("FileName").GetString());
+            Assert.Equal(id, root.GetProperty("Id").GetInt32());
+
+            var firstVersion = root.GetProperty("Versions").EnumerateArray().First();
+            Assert.Equal("this is the content", firstVersion.GetProperty("SummarizedContent").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesFromDb_WhenStorageDeletesSucceed()
+    {
+        int idToDelete;
 
         using (var db = NewDb())
         {
-            var logger = new LoggerFactory().CreateLogger<DocumentsController>();
+            CleanDocuments(db);
 
-            var storageMock = new Mock<IObjectStorage>();
-            // Force any code path that may attempt presign to fail (controller won't fail here but keep as test intent)
-            storageMock
-                .Setup(s => s.GetPresignedGetUrl(It.IsAny<string>(), It.IsAny<TimeSpan>()))
-                .Throws(new Exception("presign fail"));
+            var docs = new List<Document>
+            {
+                new Document { FileName="keep", Versions = new() {
+                    new DocumentVersion{ VersionNumber=1, ObjectKey="k1", ContentType="application/pdf", SizeBytes=0 }
+                }, CreatedAt=DateTime.UtcNow },
+                new Document { FileName="delete-me", Versions = new() {
+                    new DocumentVersion{ VersionNumber=1, ObjectKey="del1", ContentType="application/pdf", SizeBytes=0 }
+                }, CreatedAt=DateTime.UtcNow }
+            };
 
+            db.Documents.AddRange(docs);
+            await db.SaveChangesAsync();
 
-            var mqMock = new Mock<RestQueueService>();
+            foreach (var d in docs) d.CurrentVersionId = d.Versions.First().Id;
+            await db.SaveChangesAsync();
 
-            var controller = new DocumentsController(db, logger, storageMock.Object, mqMock.Object, elasticMock.Object);
-
-            result = await controller.GetDocById(id);
+            idToDelete = docs[1].Id;
         }
 
-        var ok = Assert.IsType<OkObjectResult>(result);
-        // serialize the anonymous result to JSON and assert on returned shape
-        var json = JsonSerializer.Serialize(ok.Value);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
+        using (var db = NewDb())
+        {
+            var storageMock = new Mock<IObjectStorage>();
+            storageMock
+                .Setup(s => s.RemoveObjectAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
-        Assert.Equal("this should be returned", root.GetProperty("FileName").GetString());
+            var mqMock = new Mock<IMessageQueueService>();
+            var elasticMock = new Mock<IElasticService>();
 
-        var versions = root.GetProperty("Versions").EnumerateArray();
-        var firstVersion = versions.First();
-        Assert.Equal("this is the content", firstVersion.GetProperty("SummarizedContent").GetString());
-        Assert.Equal(id, root.GetProperty("Id").GetInt32());
-    }
+            var svc = new DocumentService(
+                db,
+                NullLogger<DocumentService>.Instance,
+                storageMock.Object,
+                mqMock.Object,
+                elasticMock.Object);
 
+            // Act
+            var (found, error) = await svc.DeleteAsync(idToDelete, CancellationToken.None);
 
-    [Fact]
-    public async Task InsertDocumentThenDeleteShouldReturnOk()
-    {
-        var elasticMock = new Mock<IElasticService>();
+            // Assert
+            Assert.True(found);
+            Assert.Null(error);
 
-        using var db = NewDb();
-        CleanDocuments(db);
-
-        var docs = new List<Document>
-    {
-        new Document { FileName = "test1", Versions = new() { new DocumentVersion { VersionNumber = 1, SummarizedContent = "dummyContent", ContentType="application/pdf", SizeBytes=0 } }, CreatedAt = DateTime.UtcNow },
-        new Document { FileName = "this should be deleted", Versions = new() { new DocumentVersion { VersionNumber = 1, SummarizedContent = "this is the content", ContentType="application/pdf", SizeBytes=0 } }, CreatedAt = DateTime.UtcNow },
-        new Document { FileName = "blah", Versions = new() { new DocumentVersion { VersionNumber = 1, SummarizedContent = "blah", ContentType="application/pdf", SizeBytes=0 } }, CreatedAt = DateTime.UtcNow }
-    };
-
-        db.Documents.AddRange(docs);
-        await db.SaveChangesAsync();
-
-        foreach (var d in docs)
-            d.CurrentVersionId = d.Versions.First().Id;
-
-        await db.SaveChangesAsync();
-
-        var id = docs[1].Id;
-
-        var logger = new LoggerFactory().CreateLogger<DocumentsController>();
-
-        var storageMock = new Mock<IObjectStorage>();
-        storageMock
-            .Setup(s => s.RemoveObjectAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        var mq = new Mock<RestQueueService>().Object;
-        var controller = new DocumentsController(db, logger, storageMock.Object, mq, elasticMock.Object);
-
-        // Act
-        var deleteResult = await controller.DeleteDocById(id);
-        var getAllResult = await controller.GetAll();
-
-        // Assert delete
-        Assert.IsType<OkObjectResult>(deleteResult);
-
-        // Assert list
-        var okObject = Assert.IsType<OkObjectResult>(getAllResult);
-        var json = JsonSerializer.Serialize(okObject.Value);
-        using var jdoc = JsonDocument.Parse(json);
-        var rootArray = jdoc.RootElement;
-
-        Assert.Equal(2, rootArray.GetArrayLength());
-        Assert.DoesNotContain(rootArray.EnumerateArray(), e => e.GetProperty("Id").GetInt32() == id);
-    }
-
-
-
-    static void CleanDocuments(AppDbContext db)
-    {
-        // Ensure schema exists (and migrations are applied) before truncating
-        db.Database.Migrate();
-
-        var et = db.Model.FindEntityType(typeof(Document))!;
-        var schema = et.GetSchema() ?? "public";
-        var table = et.GetTableName()!; // EF’s actual table name
-
-        // Build raw SQL for identifiers — do NOT use ExecuteSqlInterpolated which parameterizes identifiers
-        var sql = $@"TRUNCATE TABLE ""{schema}"".""{table}"" RESTART IDENTITY CASCADE";
-        db.Database.ExecuteSqlRaw(sql);
+            var remaining = await db.Documents.AsNoTracking().ToListAsync();
+            Assert.Single(remaining);
+            Assert.Equal("keep", remaining[0].FileName);
+        }
     }
 }

--- a/PaperlessREST.Tests/DocumentsControllerTests/DocumentsControllerTests.cs
+++ b/PaperlessREST.Tests/DocumentsControllerTests/DocumentsControllerTests.cs
@@ -1,0 +1,26 @@
+﻿using Castle.Core.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using PaperlessREST.Controllers;
+using PaperlessREST.Services.Documents;
+using Xunit;
+using Microsoft.Extensions.Logging;
+
+public class DocumentsControllerTests
+{
+    [Fact]
+    public async Task GetDocById_ReturnsNotFound_WhenServiceReturnsNull()
+    {
+        var svc = new Mock<IDocumentService>();
+        svc.Setup(s => s.GetByIdAsync(123, It.IsAny<CancellationToken>()))
+           .ReturnsAsync((object?)null);
+
+        var logger = new Mock<ILogger<DocumentsController>>();
+        var controller = new DocumentsController(svc.Object, logger.Object);
+
+        var ct = CancellationToken.None;
+        var result = await controller.GetDocById(123, ct);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/PaperlessREST.Tests/Integration.Test/DocumentUploadIntegrationTest.cs
+++ b/PaperlessREST.Tests/Integration.Test/DocumentUploadIntegrationTest.cs
@@ -18,6 +18,97 @@ public class DocumentUploadIntegrationTest : IClassFixture<TestWebAppFactory>
     }
 
     [Fact]
+    public async Task UploadSameFileTwice_CreatesNewVersion_AndLinksDiffBaseVersion()
+    {
+        // Arrange: ensure DB schema is applied
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await db.Database.MigrateAsync();
+        }
+
+        var client = _factory.CreateClient();
+
+        // Two different PDF byte contents, but SAME filename (important for your versioning behavior)
+        var pdfBytesV1 = Encoding.ASCII.GetBytes("%PDF-1.4\n% v1\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF");
+        var pdfBytesV2 = Encoding.ASCII.GetBytes("%PDF-1.4\n% v2 - changed\n1 0 obj\n<< /Producer (test) >>\nendobj\ntrailer\n<<>>\n%%EOF");
+
+        // Act: upload v1
+        var resp1 = await PostPdfAsync(client, pdfBytesV1, fileName: "versioned.pdf");
+        Assert.Equal(HttpStatusCode.Created, resp1.StatusCode);
+
+        var (docId1, currentVersionId1, versionNumber1) = await ReadUploadResponseAsync(resp1);
+
+        // Act: upload v2 (same filename)
+        var resp2 = await PostPdfAsync(client, pdfBytesV2, fileName: "versioned.pdf");
+        Assert.Equal(HttpStatusCode.Created, resp2.StatusCode);
+
+        var (docId2, currentVersionId2, versionNumber2) = await ReadUploadResponseAsync(resp2);
+
+        // Assert: same document id, version increments
+        Assert.Equal(docId1, docId2);
+        Assert.Equal(1, versionNumber1);
+        Assert.Equal(2, versionNumber2);
+        Assert.NotEqual(currentVersionId1, currentVersionId2);
+
+        // Assert DB: one Document, two Versions, diff-base relationship is correct
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            var doc = await db.Documents
+                .Include(d => d.Versions)
+                .FirstOrDefaultAsync(d => d.Id == docId1);
+
+            Assert.NotNull(doc);
+            Assert.Equal("versioned.pdf", doc!.FileName);
+            Assert.Equal(currentVersionId2, doc.CurrentVersionId);
+
+            // should have 2 versions
+            Assert.Equal(2, doc.Versions.Count);
+
+            var v1 = doc.Versions.Single(v => v.Id == currentVersionId1);
+            var v2 = doc.Versions.Single(v => v.Id == currentVersionId2);
+
+            Assert.Equal(1, v1.VersionNumber);
+            Assert.Equal(2, v2.VersionNumber);
+
+            // This is your "additional use case" linkage
+            Assert.Equal(v1.Id, v2.DiffBaseVersionId);
+
+            // sanity: object keys should differ
+            Assert.False(string.IsNullOrWhiteSpace(v1.ObjectKey));
+            Assert.False(string.IsNullOrWhiteSpace(v2.ObjectKey));
+            Assert.NotEqual(v1.ObjectKey, v2.ObjectKey);
+        }
+    }
+
+    private static async Task<HttpResponseMessage> PostPdfAsync(HttpClient client, byte[] pdfBytes, string fileName)
+    {
+        using var form = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(pdfBytes);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        form.Add(fileContent, "file", fileName); // must match your controller: [FromForm] IFormFile file
+
+        return await client.PostAsync("/api/documents", form);
+    }
+
+    private static async Task<(int DocId, int CurrentVersionId, int VersionNumber)> ReadUploadResponseAsync(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(body);
+        var root = json.RootElement;
+
+        // Your controller returns:
+        // { id, fileName, currentVersionId, versionCreated, versionNumber }
+        var docId = root.GetProperty("id").GetInt32();
+        var currentVersionId = root.GetProperty("currentVersionId").GetInt32();
+        var versionNumber = root.GetProperty("versionNumber").GetInt32();
+
+        return (docId, currentVersionId, versionNumber);
+    }
+
+    [Fact]
     public async Task UploadPdf_PersistsDocumentAndVersion_AndStoresObject()
     {
         // Arrange

--- a/PaperlessREST/Program.cs
+++ b/PaperlessREST/Program.cs
@@ -4,6 +4,7 @@ using Paperless.Contracts;
 using Paperless.Contracts.SharedServices;
 using PaperlessREST.Data;
 using PaperlessREST.Services;
+using PaperlessREST.Services.Documents;
 using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,6 +13,9 @@ builder.WebHost.ConfigureKestrel(options =>
 {
     options.Limits.MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB
 });
+
+builder.Services.AddScoped<IDocumentService, DocumentService>();
+
 
 // PostgreSQL Connection
 builder.Services.AddDbContext<AppDbContext>(options =>
@@ -60,6 +64,7 @@ if (!builder.Environment.IsEnvironment("Testing"))
 {
     builder.Services.AddHostedService<RestConsumerService>();
 }
+
 
 builder.Services.AddControllers();
 var app = builder.Build();

--- a/PaperlessREST/Services/Documents/DocumentDtos.cs
+++ b/PaperlessREST/Services/Documents/DocumentDtos.cs
@@ -1,0 +1,25 @@
+﻿using Paperless.Contracts;
+
+namespace PaperlessREST.Services.Documents;
+
+public sealed record UploadDocumentResult(
+    int DocumentId,
+    string FileName,
+    int CurrentVersionId,
+    int VersionCreatedId,
+    int VersionNumber);
+
+public sealed record DocumentListItem(
+    int Id,
+    string FileName,
+    DateTime CreatedAt,
+    int? CurrentVersionId,
+    DocumentVersionSummary? Current);
+
+public sealed record DocumentVersionSummary(
+    int Id,
+    int VersionNumber,
+    long SizeBytes,
+    DocumentTag? Tag,
+    string? ChangeSummary,
+    string? SummarizedContent);

--- a/PaperlessREST/Services/Documents/DocumentService.cs
+++ b/PaperlessREST/Services/Documents/DocumentService.cs
@@ -1,0 +1,332 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Paperless.Contracts;
+using Paperless.Contracts.SharedServices;
+using Paperless.REST.Models;
+using PaperlessREST.Data;
+using PaperlessREST.Models;
+using System.Linq;
+using System.Text.Json;
+
+namespace PaperlessREST.Services.Documents;
+
+public sealed class DocumentService : IDocumentService
+{
+    private readonly AppDbContext _db;
+    private readonly ILogger<DocumentService> _logger;
+    private readonly IObjectStorage _storage;
+    private readonly IMessageQueueService _mq;
+    private readonly IElasticService _elastic;
+
+    public DocumentService(
+        AppDbContext db,
+        ILogger<DocumentService> logger,
+        IObjectStorage storage,
+        IMessageQueueService mq,
+        IElasticService elastic)
+    {
+        _db = db;
+        _logger = logger;
+        _storage = storage;
+        _mq = mq;
+        _elastic = elastic;
+    }
+
+    public async Task<IReadOnlyList<DocumentListItem>> GetAllAsync(CancellationToken ct)
+    {
+        var docs = await _db.Documents
+            .AsNoTracking()
+            .OrderByDescending(d => d.CreatedAt)
+            .Select(d => new DocumentListItem(
+                d.Id,
+                d.FileName!,
+                d.CreatedAt,
+                d.CurrentVersionId,
+                d.Versions
+                    .Where(v => v.Id == d.CurrentVersionId)
+                    .Select(v => new DocumentVersionSummary(
+                        v.Id,
+                        v.VersionNumber,
+                        v.SizeBytes,
+                        v.Tag,
+                        v.ChangeSummary,
+                        v.SummarizedContent))
+                    .FirstOrDefault()
+            ))
+            .ToListAsync(ct);
+
+        return docs;
+    }
+
+    public async Task<UploadDocumentResult> UploadAsync(IFormFile file, CancellationToken ct)
+    {
+        var fileName = Path.GetFileName(file.FileName);
+        var objectKey = $"{Guid.NewGuid():N}_{fileName}";
+
+        _logger.LogInformation("Uploading PDF {ObjectKey} (name: {FileName}, size: {Size})",
+            objectKey, file.FileName, file.Length);
+
+        // 1) store object first
+        await using (var stream = file.OpenReadStream())
+        {
+            await _storage.PutObjectAsync(stream, objectKey, "application/pdf");
+        }
+
+        await using var tx = await _db.Database.BeginTransactionAsync(ct);
+
+        try
+        {
+            // 2) doc + version in DB
+            var doc = await _db.Documents
+                .Include(d => d.Versions)
+                .FirstOrDefaultAsync(d => d.FileName == fileName, ct);
+
+            if (doc == null)
+            {
+                doc = new Document { FileName = fileName, CreatedAt = DateTime.UtcNow };
+                _db.Documents.Add(doc);
+                await _db.SaveChangesAsync(ct);
+            }
+
+            var nextVersionNumber = (doc.Versions.Count == 0)
+                ? 1
+                : doc.Versions.Max(v => v.VersionNumber) + 1;
+
+            int? baseVersionId = doc.CurrentVersionId;
+
+            var newVersion = new DocumentVersion
+            {
+                DocumentId = doc.Id,
+                VersionNumber = nextVersionNumber,
+                DiffBaseVersionId = baseVersionId,
+                ObjectKey = objectKey,
+                ContentType = "application/pdf",
+                SizeBytes = file.Length
+            };
+
+            _db.DocumentVersions.Add(newVersion);
+            await _db.SaveChangesAsync(ct);
+
+            doc.CurrentVersionId = newVersion.Id;
+            await _db.SaveChangesAsync(ct);
+
+            await tx.CommitAsync(ct);
+
+            // 3) publish event (outside tx is fine — or keep inside if you really want)
+            TryPublishVersionMessage(doc, newVersion, baseVersionId, objectKey);
+
+            _logger.LogInformation("Uploaded document saved (id: {Id}, key: {Key})", doc.Id, objectKey);
+
+            return new UploadDocumentResult(
+                doc.Id,
+                doc.FileName!,
+                doc.CurrentVersionId!.Value,
+                newVersion.Id,
+                newVersion.VersionNumber);
+        }
+        catch
+        {
+            await tx.RollbackAsync(ct);
+
+            // cleanup object if DB failed
+            try
+            {
+                await _storage.RemoveObjectAsync(objectKey);
+                _logger.LogInformation("Rolled back stored object {ObjectKey} after failure", objectKey);
+            }
+            catch (Exception cleanEx)
+            {
+                _logger.LogWarning(cleanEx, "Failed to remove object {ObjectKey} after rollback", objectKey);
+            }
+
+            throw;
+        }
+    }
+
+    private void TryPublishVersionMessage(Document doc, DocumentVersion newVersion, int? baseVersionId, string objectKey)
+    {
+        try
+        {
+            var msg = new VersionPipelineMessage(
+                DocumentId: doc.Id,
+                DocumentVersionId: newVersion.Id,
+                VersionNumber: newVersion.VersionNumber,
+                DiffBaseVersionId: baseVersionId,
+                Bucket: "documents",
+                ObjectKey: objectKey,
+                FileName: doc.FileName!,
+                ContentType: "application/pdf"
+            );
+
+            _mq.PublishTo(JsonSerializer.Serialize(msg), QueueNames.Documents);
+            _logger.LogInformation("Published upload message for doc {Id} to {Queue}", doc.Id, QueueNames.Documents);
+        }
+        catch (Exception mqEx)
+        {
+            _logger.LogWarning(mqEx, "Failed to publish message for doc {Id}", doc.Id);
+        }
+    }
+
+    public async Task<object?> GetByIdAsync(int id, CancellationToken ct)
+    {
+        var doc = await _db.Documents.AsNoTracking()
+            .Include(d => d.Versions)
+            .FirstOrDefaultAsync(d => d.Id == id, ct);
+
+        if (doc == null) return null;
+
+        return new
+        {
+            doc.Id,
+            doc.FileName,
+            doc.CreatedAt,
+            doc.CurrentVersionId,
+            Versions = doc.Versions
+                .OrderByDescending(v => v.VersionNumber)
+                .Select(v => new
+                {
+                    v.Id,
+                    v.VersionNumber,
+                    v.DiffBaseVersionId,
+                    v.SizeBytes,
+                    v.Tag,
+                    v.SummarizedContent,
+                    v.ChangeSummary
+                })
+        };
+    }
+
+    public async Task<object?> GetVersionsAsync(int docId, CancellationToken ct)
+    {
+        var doc = await _db.Documents.AsNoTracking()
+            .Where(d => d.Id == docId)
+            .Select(d => new
+            {
+                d.Id,
+                d.FileName,
+                d.CurrentVersionId,
+                Versions = d.Versions
+                    .OrderByDescending(v => v.VersionNumber)
+                    .Select(v => new
+                    {
+                        v.Id,
+                        v.VersionNumber,
+                        v.SizeBytes,
+                        v.ContentType,
+                        v.Tag,
+                        v.SummarizedContent,
+                        v.ChangeSummary,
+                        v.DiffBaseVersionId
+                    })
+                    .ToList()
+            })
+            .FirstOrDefaultAsync(ct);
+
+        return doc;
+    }
+
+    public async Task<object?> GetVersionAsync(int versionId, CancellationToken ct)
+    {
+        return await _db.DocumentVersions.AsNoTracking()
+            .Where(x => x.Id == versionId)
+            .Select(x => new
+            {
+                x.Id,
+                x.DocumentId,
+                x.VersionNumber,
+                x.Tag,
+                x.SummarizedContent,
+                x.ChangeSummary,
+                OcrText = x.Content
+            })
+            .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<object?> GetVersionOcrAsync(int versionId, CancellationToken ct)
+    {
+        return await _db.DocumentVersions.AsNoTracking()
+            .Where(x => x.Id == versionId)
+            .Select(x => new { x.Id, OcrText = x.Content })
+            .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<(Stream Stream, string ContentType, string DownloadName)?> DownloadVersionAsync(int versionId, CancellationToken ct)
+    {
+        var v = await _db.DocumentVersions.AsNoTracking()
+            .Where(x => x.Id == versionId)
+            .Select(x => new { x.ObjectKey, x.ContentType })
+            .FirstOrDefaultAsync(ct);
+
+        if (v == null) return null;
+
+        var stream = await _storage.GetObjectAsync(v.ObjectKey);
+        return (stream, v.ContentType, $"version-{versionId}.pdf");
+    }
+
+    public async Task<(Stream Stream, string ContentType, string DownloadName)?> DownloadCurrentAsync(int docId, CancellationToken ct)
+    {
+        var doc = await _db.Documents.AsNoTracking().FirstOrDefaultAsync(d => d.Id == docId, ct);
+        if (doc == null) return null;
+
+        var version = await _db.DocumentVersions.AsNoTracking()
+            .FirstOrDefaultAsync(v => v.Id == doc.CurrentVersionId, ct);
+
+        if (version == null) return null;
+
+        var stream = await _storage.GetObjectAsync(version.ObjectKey);
+        return (stream, "application/pdf", doc.FileName!);
+    }
+
+    public async Task<bool> SetCurrentVersionAsync(int docId, int versionId, CancellationToken ct)
+    {
+        var doc = await _db.Documents.FirstOrDefaultAsync(d => d.Id == docId, ct);
+        if (doc == null) return false;
+
+        var exists = await _db.DocumentVersions.AnyAsync(v => v.Id == versionId && v.DocumentId == docId, ct);
+        if (!exists) throw new InvalidOperationException("Version does not belong to document.");
+
+        doc.CurrentVersionId = versionId;
+        await _db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<(bool Found, string? Error)> DeleteAsync(int docId, CancellationToken ct)
+    {
+        var doc = await _db.Documents
+            .Include(d => d.Versions)
+            .FirstOrDefaultAsync(d => d.Id == docId, ct);
+
+        if (doc == null) return (false, null);
+
+        var failedKeys = new List<string>();
+
+        foreach (var v in doc.Versions)
+        {
+            if (string.IsNullOrWhiteSpace(v.ObjectKey))
+                continue;
+
+            try { await _storage.RemoveObjectAsync(v.ObjectKey); }
+            catch { failedKeys.Add(v.ObjectKey); }
+        }
+
+        if (failedKeys.Count > 0)
+            return (true, $"Failed to remove {failedKeys.Count} object(s) from storage. Aborting DB delete.");
+
+        await using var tx = await _db.Database.BeginTransactionAsync(ct);
+
+        doc.CurrentVersionId = null;
+        await _db.SaveChangesAsync(ct);
+
+        _db.DocumentVersions.RemoveRange(doc.Versions);
+        _db.Documents.Remove(doc);
+
+        await _db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        return (true, null);
+    }
+
+    public async Task<IEnumerable<MessageTransferObject>> SearchAsync(string query, CancellationToken ct)
+        => await _elastic.SearchAsync(query);
+}

--- a/PaperlessREST/Services/Documents/IDocumentService.cs
+++ b/PaperlessREST/Services/Documents/IDocumentService.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace PaperlessREST.Services.Documents;
+
+public interface IDocumentService
+{
+    Task<IReadOnlyList<DocumentListItem>> GetAllAsync(CancellationToken ct);
+
+    Task<UploadDocumentResult> UploadAsync(IFormFile file, CancellationToken ct);
+
+    Task<object?> GetByIdAsync(int id, CancellationToken ct); // keep anonymous shape if you want
+    Task<object?> GetVersionsAsync(int docId, CancellationToken ct);
+
+    Task<(Stream Stream, string ContentType, string DownloadName)?> DownloadCurrentAsync(int docId, CancellationToken ct);
+    Task<(Stream Stream, string ContentType, string DownloadName)?> DownloadVersionAsync(int versionId, CancellationToken ct);
+
+    Task<object?> GetVersionAsync(int versionId, CancellationToken ct);
+    Task<object?> GetVersionOcrAsync(int versionId, CancellationToken ct);
+
+    Task<bool> SetCurrentVersionAsync(int docId, int versionId, CancellationToken ct);
+
+    Task<(bool Found, string? Error)> DeleteAsync(int docId, CancellationToken ct);
+
+    Task<IEnumerable<Paperless.Contracts.MessageTransferObject>> SearchAsync(string query, CancellationToken ct);
+}


### PR DESCRIPTION
- Add IDocumentService/DocumentService to encapsulate all document logic (upload, retrieval, versioning, download, delete)
- Refactor DocumentsController to use the service; remove direct DbContext/storage access
- Implement document versioning: uploading same filename creates new version with diff base
- Add DTOs for consistent API responses
- Update endpoints for clarity and service-based routing
- Ensure transactional integrity and object cleanup on failure
- Expand tests: add DocumentServiceTests, integration test for versioning, and controller not-found test
- Improve RestConsumerService error handling and reconnect logic
- Update README with versioning/AI use case and architecture diagram
- Register service in DI and update Program.cs accordingly